### PR TITLE
Fix chdir to npm package name (should be to repo name)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 var repoUrl = require('repo-url');
 var spawn = require('child_process').spawn;
+var parseUrl = require('url').parse;
+var basename = require('path').basename;
+
 var commands = process.argv.slice(2);
 
 var name = commands.pop();
@@ -22,7 +25,10 @@ get(name, function (err, url) {
 
   run('git', ['clone', url], function (code) {
     if (code != 0) process.exit(code);
-    process.chdir(process.cwd() + '/' + name);
+
+    var repoUrlPath = parseUrl(url).pathname;
+    var dir = basename(repoUrlPath).replace(/\.git$/, '');
+    process.chdir(process.cwd() + '/' + dir);
 
     if (cmd('install') || cmd('test') || cmd('all')) {
       run('npm', ['install'], function (code) {


### PR DESCRIPTION
npm-clone does chdir to the package name, though there are packages whose repo name and package name are different. For example, when I do:

```
$ npm-clone octokit
Cloning into 'octokit.js'...

/usr/local/lib/node_modules/npm-clone/node_modules/repo-url/node_modules/silent-npm-registry-client/node_modules/npm-registry-client/node_modules/graceful-fs/polyfills.js:14
  chdir.call(process, d)
        ^
Error: ENOENT, no such file or directory
    at process.chdir (/usr/local/lib/node_modules/npm-clone/node_modules/repo-url/node_modules/silent-npm-registry-client/node_modules/npm-registry-client/node_modules/graceful-fs/polyfills.js:14:9)
    at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm-clone/index.js:25:13)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at Process.ChildProcess._handle.onexit (child_process.js:789:12)
```

npm package name is `octokit`, while the repo name is `octokit.js`.
