### PR TITLE
Add --global install (npm link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ npm-clone all periodic
 
 # flags still apply
 npm-clone --ssh all periodic
+
+# link globally
+npm-clone --global install periodic
 ```
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ function help() {
   console.log('');
   console.log('Usage');
   console.log('  $ npm-clone [FLAG] [TYPE] <module-name>');
-  console.log('  Types: all, install, test');
-  console.log('  Flags: --ssh, --https');
+  console.log('  Types: all, install, test, link');
+  console.log('  Flags: --ssh, --https, --global');
   console.log('');
   console.log('Example');
   console.log('  $ npm-clone --ssh all periodic');
@@ -51,7 +51,7 @@ get(name, function (err, url) {
     process.chdir(name);
 
     if (cmd('install') || cmd('test') || cmd('all')) {
-      run('npm', ['install'], function (code) {
+      run('npm', [cmd('global') ? 'link' : 'install'], function (code) {
         if (code != 0) process.exit(code);
 
         if (cmd('test') || cmd('all')) {


### PR DESCRIPTION
This allows for a flag `--global`, that will `npm link` the cloned module